### PR TITLE
Correct the spelling of Xcode in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ Some notes about the export/import format:
 
 ## Requirements
 
-iOS 9.0, XCode 7
+iOS 9.0, Xcode 7
 
 ## Installation
 


### PR DESCRIPTION
This pull request corrects the spelling of **Xcode** :sweat_smile:
https://developer.apple.com/xcode/

Created with [`xcode-readme`](https://github.com/dkhamsing/xcode-readme).
